### PR TITLE
Resiliancy to unlink failures during cleanup and support for data download behind a proxy

### DIFF
--- a/perl/bin/download_generate_bberg_ref_files.pl
+++ b/perl/bin/download_generate_bberg_ref_files.pl
@@ -283,7 +283,7 @@ sub download_unpack_files{
 	my ($opts) = @_;
 	my $impute_download = $opts->{'u'}.sprintf($IMPUTE_TGZ_PATTERN,$DOWNLOAD_VERSION);
 	my $imputetgz = File::Spec->catfile($opts->{'tmp'}, sprintf($IMPUTE_TGZ_PATTERN,$DOWNLOAD_VERSION));
-	download_file($impute_download,$imputetgz) unless(-e $imputetgz.'.dl_success');
+	download_file($impute_download,$imputetgz,$opts->{'c'}) unless(-e $imputetgz.'.dl_success');
 	unpack_file($imputetgz,$opts->{'tmp'},'tgz');
 	return;
 }
@@ -296,16 +296,20 @@ sub unpack_file{
 }
 
 sub download_file{
-	my ($url,$file) = @_;
-	my $dirname  = dirname($file);
-	$File::Fetch::BLACKLIST = [qw(lwp)];
-	$url =~ s/^https/http/;
-	my $ff = File::Fetch->new(uri => $url);
-	my $local = $ff->fetch(to => $dirname) or croak $ff->error;
-	# if the filename isn't what we expect move it
-	unless($local eq $file) {
-	  move($local, $file) or croak $!;
-	}
+	my ($url,$file,$use_curl) = @_;
+        if $use_curl {
+          my $output = `curl --location $url > $file`;
+        } else {
+          my $dirname  = dirname($file);
+          $File::Fetch::BLACKLIST = [qw(lwp)];
+          $url =~ s/^https/http/;
+          my $ff = File::Fetch->new(uri => $url);
+          my $local = $ff->fetch(to => $dirname) or croak $ff->error;
+          # if the filename isn't what we expect move it
+          unless($local eq $file) {
+            move($local, $file) or croak $!;
+          }
+        }
 	# touch a file to show the archive is complete and not partial to prevent re-dl (3.7GB) if this bit is successful
 	# likely use case would be running out of disk space during unpacking intermediate space required is ~16GB
 	my $success_file = $file.'.dl_success';
@@ -323,6 +327,7 @@ sub setup{
   				'h|help' => \$opts{'h'},
 					'm|man' => \$opts{'m'},
 					'v|version' => \$opts{'v'},
+					'c|use-curl' => \$opts{'c'},
 					'o|out-dir=s' => \$opts{'o'},
 					'd|download-version=s' => \$opts{'d'},
           'u|url=s' => \$opts{'u'},
@@ -375,6 +380,7 @@ download_generate_bberg_ref_files.pl [options]
 
     Optional parameters:
       -url                      -u  URL to download battenberg impute reference data from [see docs for default url]
+      -use-curl                 -c  Use curl for the download
       -download-version         -d  Download version (part of download name) default: [v3]
 
     Other:

--- a/perl/bin/download_generate_bberg_ref_files.pl
+++ b/perl/bin/download_generate_bberg_ref_files.pl
@@ -297,7 +297,7 @@ sub unpack_file{
 
 sub download_file{
 	my ($url,$file,$use_curl) = @_;
-        if $use_curl {
+        if ($use_curl) {
           my $output = `curl --location $url > $file`;
         } else {
           my $dirname  = dirname($file);

--- a/perl/lib/Sanger/CGP/Battenberg.pm
+++ b/perl/lib/Sanger/CGP/Battenberg.pm
@@ -25,7 +25,7 @@ use strict;
 
 use Const::Fast qw(const);
 use base 'Exporter';
-our $VERSION = '1.3.2_04';
+our $VERSION = '1.3.2_05';
 our @EXPORT = qw($VERSION);
 
 const my $LICENSE =>

--- a/perl/lib/Sanger/CGP/Battenberg.pm
+++ b/perl/lib/Sanger/CGP/Battenberg.pm
@@ -25,7 +25,7 @@ use strict;
 
 use Const::Fast qw(const);
 use base 'Exporter';
-our $VERSION = '1.3.2_03';
+our $VERSION = '1.3.2_04';
 our @EXPORT = qw($VERSION);
 
 const my $LICENSE =>

--- a/perl/lib/Sanger/CGP/Battenberg.pm
+++ b/perl/lib/Sanger/CGP/Battenberg.pm
@@ -25,7 +25,7 @@ use strict;
 
 use Const::Fast qw(const);
 use base 'Exporter';
-our $VERSION = '1.3.2_01';
+our $VERSION = '1.3.2_02';
 our @EXPORT = qw($VERSION);
 
 const my $LICENSE =>

--- a/perl/lib/Sanger/CGP/Battenberg.pm
+++ b/perl/lib/Sanger/CGP/Battenberg.pm
@@ -25,7 +25,7 @@ use strict;
 
 use Const::Fast qw(const);
 use base 'Exporter';
-our $VERSION = '1.3.2_06';
+our $VERSION = '1.3.2_07';
 our @EXPORT = qw($VERSION);
 
 const my $LICENSE =>

--- a/perl/lib/Sanger/CGP/Battenberg.pm
+++ b/perl/lib/Sanger/CGP/Battenberg.pm
@@ -25,7 +25,7 @@ use strict;
 
 use Const::Fast qw(const);
 use base 'Exporter';
-our $VERSION = '1.3.1';
+our $VERSION = '1.3.2_01';
 our @EXPORT = qw($VERSION);
 
 const my $LICENSE =>

--- a/perl/lib/Sanger/CGP/Battenberg.pm
+++ b/perl/lib/Sanger/CGP/Battenberg.pm
@@ -25,7 +25,7 @@ use strict;
 
 use Const::Fast qw(const);
 use base 'Exporter';
-our $VERSION = '1.3.2_05';
+our $VERSION = '1.3.2_06';
 our @EXPORT = qw($VERSION);
 
 const my $LICENSE =>

--- a/perl/lib/Sanger/CGP/Battenberg.pm
+++ b/perl/lib/Sanger/CGP/Battenberg.pm
@@ -25,7 +25,7 @@ use strict;
 
 use Const::Fast qw(const);
 use base 'Exporter';
-our $VERSION = '1.3.2_02';
+our $VERSION = '1.3.2_03';
 our @EXPORT = qw($VERSION);
 
 const my $LICENSE =>

--- a/perl/lib/Sanger/CGP/Battenberg/Implement.pm
+++ b/perl/lib/Sanger/CGP/Battenberg/Implement.pm
@@ -835,8 +835,10 @@ sub _zip_and_tar_fileset{
 			$file = File::Spec->catfile($location,sprintf($filepattern,$sample_name,$i+1));
 			next if($options->{'is_male'} && $file =~ m/chr(X|23)/ && ! -e $file); #Skip if male and X results aren't present, this is allowed...
 		}
-		PCAP::Cli::file_for_reading('file for tar.gz',$file);
-		push(@files,$file);
+		if (-e $file) {
+		  PCAP::Cli::file_for_reading('file for tar.gz',$file);
+		  push(@files,$file);
+		}
 	}
 
 	my $tarball = _targzFileSet($options,\@files,$tar,$dir);
@@ -933,6 +935,7 @@ sub read_contigs_from_file_with_ignore{
     		my $line = $_;
     		chomp($line);
     		my ($con,undef) = split(/\s+/,$line);
+    		$con =~ s/chr//;  # handle hg19, removing chr prefix
     		my $match=0;
     		foreach my $ign(@$ignore_contigs){
     			if("$ign" eq "$con"){

--- a/perl/lib/Sanger/CGP/Battenberg/Implement.pm
+++ b/perl/lib/Sanger/CGP/Battenberg/Implement.pm
@@ -675,7 +675,7 @@ sub battenberg_finalise{
 		#Tumour png
 		my $tumour = File::Spec->catfile($tmp,sprintf($TUMOUR_PNG,$tumour_name,$tumour_dot));
 		my $tumour_copy = File::Spec->catfile($outdir,sprintf($TUMOUR_CORRECTED_PNG,$tumour_name));
-                if (-e $tumor) {
+                if (-e $tumour) {
                        _copy_file($tumour,$tumour_copy);
                 }
 		#Normal png

--- a/perl/lib/Sanger/CGP/Battenberg/Implement.pm
+++ b/perl/lib/Sanger/CGP/Battenberg/Implement.pm
@@ -631,7 +631,9 @@ sub battenberg_finalise{
 		for(my $i=1; $i<=$options->{'job_count'}; $i++){
 			my $file = File::Spec->catfile($tmp,sprintf($IMPUTE_INPUT,$options->{'tumour_name'},$i));
 			next if($options->{'is_male'} && $file =~ m/chr(X|23)/ && ! -e $file); #Skip if male and X results aren't present, this is allowed...
-			unlink glob $file;
+	                foreach my $file_to_del (glob $file){
+	                       unlink($file_to_del) or print "Could not unlink $file_to_del";
+	                }
 		}
 		PCAP::Threaded::touch_success(File::Spec->catdir($tmp, 'progress'), @{['cleanup_impute',0]});
 	}
@@ -673,11 +675,15 @@ sub battenberg_finalise{
 		#Tumour png
 		my $tumour = File::Spec->catfile($tmp,sprintf($TUMOUR_PNG,$tumour_name,$tumour_dot));
 		my $tumour_copy = File::Spec->catfile($outdir,sprintf($TUMOUR_CORRECTED_PNG,$tumour_name));
-		_copy_file($tumour,$tumour_copy);
+                if (-e $tumor) {
+                       _copy_file($tumour,$tumour_copy);
+                }
 		#Normal png
 		my $normal = File::Spec->catfile($tmp,sprintf($NORMAL_PNG,$tumour_name,$tumour_dot));
 		my $normal_copy = File::Spec->catfile($outdir,sprintf($NORMAL_CORRECTED_PNG,$tumour_name));
-		_copy_file($normal,$normal_copy);
+                if (-e $normal) {
+                        _copy_file($normal,$normal_copy);
+                }
 
     tmp_to_outdir($tmp, $outdir, $tumour_name,
                   $SUNRISE_PNG, $COPY_NO_PNG, $NON_ROUNDED_PNG, $ALT_COPY_NO_ROUNDED_PNG,
@@ -839,7 +845,7 @@ sub _zip_and_tar_fileset{
 	die("Error: Failed to copy file $tarball to $copied_loc.") if(!copy($tarball,$copied_loc));
 	push(@files,$tarball);
 	foreach my $file_to_del (@files){
-		unlink($file_to_del);
+		unlink($file_to_del) or print "Could not unlink $file_to_del";
 	}
 	return;
 }

--- a/perl/share/battenberg/FitCopyNumber.R
+++ b/perl/share/battenberg/FitCopyNumber.R
@@ -81,6 +81,7 @@ for(chr in chr.names){
 	indices = match(chr.segmented.BAF.data[,2],chr.logR.data$Position)
 	logR.data = rbind(logR.data, chr.logR.data[indices[!is.na(indices)],])
 	chr.segmented.logR.data = chr.logR.data[indices[!is.na(indices)],]
+	if(length(chr.segmented.BAF.data[,5])==0){next}
 	segs = make_seg_lr(chr.segmented.BAF.data[,5])
 	cum.segs = c(0,cumsum(segs))
 	for(s in 1:length(segs)){

--- a/perl/share/battenberg/FitCopyNumber.R
+++ b/perl/share/battenberg/FitCopyNumber.R
@@ -60,14 +60,6 @@ raw.logR.data = read.table(paste(start.file,"mutantLogR.tab",sep=""),sep="\t",he
 raw.BAF.data = raw.BAF.data[!is.na(raw.BAF.data[,3]),]
 raw.logR.data = raw.logR.data[!is.na(raw.logR.data[,3]),]
 
-#chromosome names are sometimes 'chr1', etc.
-if(length(grep("chr",raw.BAF.data[1,1]))>0){
-	raw.BAF.data[,1] = gsub("chr","",raw.BAF.data[,1])
-}
-if(length(grep("chr",raw.logR.data[1,1]))>0){
-	raw.logR.data[,1] = gsub("chr","",raw.logR.data[,1])
-}
-
 BAF.data = NULL
 logR.data = NULL
 segmented.logR.data = NULL

--- a/perl/share/battenberg/GetHaplotypedBAFs.R
+++ b/perl/share/battenberg/GetHaplotypedBAFs.R
@@ -63,5 +63,9 @@ GetChromosomeBAFs<-function(chr, SNP_file, startHaplotypeFile,endHaplotypeFile, 
 	alt.count = alt.count[min_indices]
 
 	hetMutBAFs<-cbind(chr_name,filtered_snp_data[,2],alt.count/denom)
+	if(is.null(nrow(filtered_snp_data[,2]))){
+		write.table(array(NA,c(0,3)),outfile,sep="\t",col.names=c("Chromosome","Position",samplename),quote=F)
+		return()
+	}
 	write.table(hetMutBAFs,outfile,sep="\t",row.names=paste("snp",1:nrow(hetMutBAFs),sep=""),col.names=c("Chromosome","Position",samplename),quote=F)
 }

--- a/perl/share/battenberg/PlotHaplotypedData.R
+++ b/perl/share/battenberg/PlotHaplotypedData.R
@@ -30,7 +30,8 @@ impute.info = read.table(imputeInfoFile,header=F,row.names=NULL,sep="\t",strings
 chr_names=unique(impute.info[,1])
 chr_name = chr_names[chr]
 
-imageFileName = paste(samplename,"_chr",chr_name,"_heterozygousData.png",sep="")
+imageFileName = paste(samplename,"_",ifelse(grepl("chr", chr_name), "", "chr"),
+                      chr_name,"_heterozygousData.png",sep="")
 
 mut_data<-read.table(mutFile,sep="\t",header=T)
 

--- a/perl/share/battenberg/RunBAFLogR.R
+++ b/perl/share/battenberg/RunBAFLogR.R
@@ -36,7 +36,9 @@ getBAFsAndLogRs(imputeInfoFile,inputFile,normalInputFile,paste(outputDir,"normal
 
 # This is a workaround such that BB doesnt have to be rerun across a lot of samples. The problem is that when ASCAT reads in a file it changes two things: If the samplename starts with a number it places an X in front of the name and underscores are replaced by dots. ascat.loadData was extended to take the real samplenames and place those in the header of the read in data files. However that changes the other underscores and dots thing as well and that changes filenames. We therefore place the dots in the samplenames such that ASCAT will produce the file with dots in it. A complete fix will be added at a later date.
 samplename = gsub("\\-", "\\.", samplename)
-ascat.bc = ascat.loadData(paste(outputDir,"mutantLogR.tab",sep=""),paste(outputDir,"mutantBAF.tab",sep=""),paste(outputDir,"normalLogR.tab",sep=""),paste(outputDir,"normalBAF.tab",sep=""), samplenames=c(samplename))
+impute.info = read.table(imputeInfoFile,header=F,row.names=NULL,sep="\t",stringsAsFactors=F)
+chr_names=unique(impute.info[,1])
+ascat.bc = ascat.loadData(paste(outputDir,"mutantLogR.tab",sep=""),paste(outputDir,"mutantBAF.tab",sep=""),paste(outputDir,"normalLogR.tab",sep=""),paste(outputDir,"normalBAF.tab",sep=""), samplenames=c(samplename), chrs=chr_names)
 ascat.plotRawData(ascat.bc, parentDir=outputDir)
 
 q(save="no")

--- a/perl/share/battenberg/callSubclones.R
+++ b/perl/share/battenberg/callSubclones.R
@@ -264,7 +264,8 @@ for (chr in chr_names) {
   LogRchr = LogRvals[LogRvals[,1]==chr,3]
   LogRposke = LogRvals[LogRvals[,1]==chr,2]
 
-  png(filename = paste(start.file,"_subclones_chr",chr,".png",sep=""), width = 2000, height = 2000, res = 200)
+  png(filename = paste(start.file,"_subclones_",ifelse(grepl("chr", chr), "", "chr"),
+                       chr,".png",sep=""), width = 2000, height = 2000, res = 200)
   par(mar = c(2.5,2.5,2.5,0.25), cex = 0.4, cex.main=1.5, cex.axis = 1, cex.lab = 1, mfrow = c(2,1))
   plot(c(min(pos)/1000000,max(pos)/1000000),c(-1,1),pch=".",type = "n",
        main = paste(sample.name,", chromosome ", chr, sep=""), xlab = "Position (Mb)", ylab = "LogR")

--- a/perl/share/battenberg/callSubclones.R
+++ b/perl/share/battenberg/callSubclones.R
@@ -164,7 +164,7 @@ for (i in 1:length(BAFlevels)) {
   whichclosestlevel.test = which.min(abs(test.levels-l))
 
   #270713 - problem caused by segments with constant BAF (usually 1 or 2)
-  if(sd(BAFke)==0){
+  if(is.na(sd(BAFke)) || sd(BAFke)==0){
 	  pval[i]=0
   }else{
   	#pval[i] = t.test(BAFke,alternative="two.sided",mu=levels[whichclosestlevel])$p.value

--- a/perl/share/battenberg/segmentBAFphased.R
+++ b/perl/share/battenberg/segmentBAFphased.R
@@ -77,7 +77,8 @@ for (chr in unique(BAFraw[,1])) {
     BAFsegm = res$yhat
   }
 
-  png(filename = paste(sample,"_RAFseg_chr",chr,".png",sep=""), width = 2000, height = 1000, res = 200)
+  png(filename = paste(sample,"_RAFseg_",ifelse(grepl("chr", chr), "", "chr"),
+                       chr,".png",sep=""), width = 2000, height = 1000, res = 200)
   par(mar = c(5,5,5,0.5), cex = 0.4, cex.main=3, cex.axis = 2, cex.lab = 2)
   plot(c(min(pos)/1000000,max(pos)/1000000),c(0,1),pch=".",type = "n",
 	   main = paste(sample,", chromosome ", chr, sep=""), xlab = "Position (Mb)", ylab = "BAF (phased)")
@@ -94,7 +95,8 @@ for (chr in unique(BAFraw[,1])) {
   	BAFphseg = res$yhat
   }
 
-  png(filename = paste(sample,"_chr",chr,".png",sep=""), width = 2000, height = 1000, res = 200)
+  png(filename = paste(sample,"_",ifelse(grepl("chr", chr), "", "chr"),
+                       chr,".png",sep=""), width = 2000, height = 1000, res = 200)
   par(mar = c(5,5,5,0.5), cex = 0.4, cex.main=3, cex.axis = 2, cex.lab = 2)
   plot(c(min(pos)/1000000,max(pos)/1000000),c(0,1),pch=".",type = "n",
 	   main = paste(sample,", chromosome ", chr, sep=""), xlab = "Position (Mb)", ylab = "BAF (phased)")


### PR DESCRIPTION
Thank you for Battenberg. We've been working on integrating it into bcbio (https://github.com/chapmanb/bcbio-nextgen) and have been using it with good success to estimate normal contamination. I ran into a couple of small issues during data preparation and in production runs that this pull request addresses:

- It provides an option to use curl for data download. I could not make `File::Fetch` work behind a proxy, but curl works cleanly and provides a useful alternative for folks who don't mind the external dependency.
- It avoids failing when unable to unlink a file during a re-run of a partially finished analysis. Battenberg can occasionally end up in a state where a file it wants to unlink is already removed, and this avoids dying when this happens.

Thanks again for your work on this. Please let me know if you need any other details.